### PR TITLE
Make html2text UNICODE_SNOB by default

### DIFF
--- a/html2text/config.py
+++ b/html2text/config.py
@@ -1,7 +1,7 @@
 import re
 
 # Use Unicode characters instead of their ascii psuedo-replacements
-UNICODE_SNOB = 0
+UNICODE_SNOB = True
 
 # Marker to use for marking tables for padding post processing
 TABLE_MARKER_FOR_PAD = "special_marker_for_table_padding"

--- a/test/data/break_and_bold.md
+++ b/test/data/break_and_bold.md
@@ -1,5 +1,5 @@
 **German Speaking Recruitment Coordinator**  
   
 
- **What will you do?**
+ **What will you do?**
 

--- a/test/data/emdash-para.md
+++ b/test/data/emdash-para.md
@@ -1,15 +1,15 @@
 Bacon ipsum dolor sit amet pork chop id pork belly ham hock, sed meatloaf eu
 exercitation flank quis veniam officia. Chuck dolor esse, occaecat est elit
 drumstick ground round tri-tip nisi. Eu fugiat drumstick leberkas magna.
-Turducken frankfurter nisi aute shank--
+Turducken frankfurter nisi aute shank—
 
---irure ex esse id, ham commodo meatloaf pig pariatur ut cow. Officia salami
-in fatback voluptate boudin ullamco beef ribs shank. Duis spare ribs pork
-chop, ad leberkas reprehenderit id voluptate salami ham ut in ut cillum
-turducken. Nisi ribeye tail capicola dolore andouille. Short ribs id beef
-ribs, et nulla ground round do sunt dolore. Dolore nisi ullamco veniam sunt.
-Duis brisket drumstick, dolor fatback filet mignon meatloaf laboris tri-tip
-speck chuck ball tip voluptate ullamco laborum.
+—irure ex esse id, ham commodo meatloaf pig pariatur ut cow. Officia salami in
+fatback voluptate boudin ullamco beef ribs shank. Duis spare ribs pork chop,
+ad leberkas reprehenderit id voluptate salami ham ut in ut cillum turducken.
+Nisi ribeye tail capicola dolore andouille. Short ribs id beef ribs, et nulla
+ground round do sunt dolore. Dolore nisi ullamco veniam sunt. Duis brisket
+drumstick, dolor fatback filet mignon meatloaf laboris tri-tip speck chuck
+ball tip voluptate ullamco laborum.
 
 \--
 

--- a/test/data/nbsp.html
+++ b/test/data/nbsp.html
@@ -5,7 +5,7 @@
   <body>
     <h1>NBSP handling test #1</h1>
 
-    <p>In this test all NBSPs will be replaced with ordinary spaces (unicode_snob = False).</p>
+    <p>In this test all NBSPs will NOT be replaced with ordinary spaces (unicode_snob = True).</p>
 
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do&nbsp;eiusmod
     tempor incididunt ut&nbsp;labore et&nbsp;dolore magna aliqua. Ut&nbsp;enim ad&nbsp;minim veniam,

--- a/test/data/nbsp.md
+++ b/test/data/nbsp.md
@@ -1,14 +1,14 @@
 # NBSP handling test #1
 
-In this test all NBSPs will be replaced with ordinary spaces (unicode_snob =
-False).
+In this test all NBSPs will NOT be replaced with ordinary spaces (unicode_snob
+= True).
 
-Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
 consequat.
 
-Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
-eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
-in culpa qui officia deserunt mollit anim id est laborum.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum.
 

--- a/test/data/umlauts_and_specials.html
+++ b/test/data/umlauts_and_specials.html
@@ -1,0 +1,1 @@
+<span>bist Du</span> f<span style="font-family: Verdana, sans-serif;">&uuml;</span>r<span style="font-family: arial , helvetica , sans-serif;"> die Neukunden Akquise verantwortlich</span>

--- a/test/data/umlauts_and_specials.md
+++ b/test/data/umlauts_and_specials.md
@@ -1,0 +1,2 @@
+bist Du für die Neukunden Akquise verantwortlich
+


### PR DESCRIPTION
(And fix tests accordingly)

I don't think there's an actual use case to convert unicode chars to their ascii pseudo-equivalent.